### PR TITLE
Refactor cryptographic API

### DIFF
--- a/lib/log.ts
+++ b/lib/log.ts
@@ -24,6 +24,18 @@ export class Log {
     this.info("Error:", err.toString());
   }
 
+  assertTrue(result: boolean, ...msgs) {
+    if (!result) {
+      throw new Error([...msgs].join(":"));
+    }
+  }
+
+  assertFalse(result: boolean, ...msgs) {
+    if (result) {
+      throw new Error([...msgs].join(":"));
+    }
+  }
+
   assert(a: any, b: any, ...msgs){
     this.test(true, a, b, ...msgs);
   }

--- a/lib/mcl.ts
+++ b/lib/mcl.ts
@@ -1,5 +1,4 @@
 import * as mcl from "mcl-wasm";
-import {crypto_hash_sha256} from "./sodium";
 
 export function waitReady(): Promise<undefined> {
     return new Promise((resolve) => {
@@ -20,7 +19,7 @@ export function add<T extends Fr | G1 | G2 | GT>(a: T, b: T): any {
         return new G2(mcl.add(a.mclG2, b.mclG2));
     }
     if (a instanceof GT && b instanceof GT) {
-        return new GT(mcl.add(a.mclGT, b.mclGT));
+        return new GT(mcl.mul(a.mclGT, b.mclGT));
     }
 }
 
@@ -35,7 +34,7 @@ export function mul(a: Fr | G1 | G2 | GT, b: Fr): any {
         return new G2(mcl.mul(a.mclG2, b.mclFr))
     }
     if (a instanceof GT) {
-        return new GT(mcl.mul(a.mclGT, b.mclFr))
+        return new GT(mcl.pow(a.mclGT, b.mclFr))
     }
     throw new Error("Cannot use this as input type")
 }
@@ -105,6 +104,10 @@ export class Fr {
 
     setByCSPRNG() {
         this.mclFr.setByCSPRNG();
+    }
+
+    setFromArray(arr: Uint8Array) {
+        this.mclFr.setLittleEndianMod(arr)
     }
 
     serialize(): Uint8Array {

--- a/v2/crypto.spec.ts
+++ b/v2/crypto.spec.ts
@@ -1,60 +1,372 @@
-import {Section7, waitReady} from "./crypto";
+import {randombytes_buf, crypto_hash_sha256} from "../lib/sodium";
+import * as mcl from "../lib/mcl";
+
+import {CrowdNotifierPrimitives, IBEPrimitives, Helpers, waitReady} from "./crypto";
 import {Log} from "../lib/log";
 
 /**
- * Very simple crypto test for the section7 using the new BNS scheme to avoid having to
+ * Very simple crypto test for the CrowdNotifierPrimitives using the new BNS scheme to avoid having to
  * print new QRcodes after every infection.
  *
  * To run it, write:
  *   npm ci
- *   npm run section7
+ *   npm run CrowdNotifierPrimitives
  */
 
 const log = new Log("v2/crypto.spec");
 log.info(`Starting at: ${new Date()}`);
 
-async function main() {
-    await waitReady();
 
+function testIbePrimitives() {
+    const id = new Uint8Array([1,2,3,4]);
+    const msg = new Uint8Array([5,6,7,8,9,10,11,12,13,14,15,1,2,3,4]);
+    
+    log.info("Start test suite for identity-based encryption (IBE) primitives.");
+
+    log.info("Keys generation");
+    const [mpk, mskh, mskv] = IBEPrimitives.keyGen();
+    const msk = mcl.add(mskh, mskv);
+
+    log.info("Encrypt");
+    const ctxt = IBEPrimitives.enc(mpk, id, msg);
+
+    log.info("Derive key");
+    const skid = IBEPrimitives.keyDer(msk, id);
+
+    log.info("Decrypt");
+    const msg_dec = IBEPrimitives.dec(id, skid, ctxt);
+
+    log.reject(msg_dec, undefined, "Should be able to decrypt message!")
+
+    log.assert(msg, msg_dec, "Original message and decrypted ciphertext should be equal!")
+
+    log.info("All tests for IBE primitives passed!");
+}
+
+
+function testCrowdNotifierPrimitives() {
     log.info("Setting up backends");
-    const HealthAuthority = Section7.setupHA();
+    const HealthAuthority = CrowdNotifierPrimitives.setupHealthAuthority();
     const infoLocation1 = "FooBar:Lausanne:undefined";
-    const location1 = Section7.genCode(infoLocation1, HealthAuthority.publicKey);
+    const location1 = CrowdNotifierPrimitives.genCode(infoLocation1, HealthAuthority.publicKey);
     const infoLocation2 = "BarMitzva:Lausanne:undefined";
-    const location2 = Section7.genCode(infoLocation2, HealthAuthority.publicKey);
+    const location2 = CrowdNotifierPrimitives.genCode(infoLocation2, HealthAuthority.publicKey);
 
     log.info("Creating two users");
     const counter1 = 1000;
     const user1Aux = "secret date";
-    const user1 = Section7.scan(location1.ent, location1.pEnt, infoLocation1, counter1, user1Aux);
+    const user1 = CrowdNotifierPrimitives.scan(location1.ent, location1.pEnt, infoLocation1, counter1, user1Aux);
 
     const counter2 = 1001;
     const user2Aux = "PARTY!";
-    const user2 = Section7.scan(location2.ent, location2.pEnt, infoLocation2, counter2, user2Aux);
+    const user2 = CrowdNotifierPrimitives.scan(location2.ent, location2.pEnt, infoLocation2, counter2, user2Aux);
 
     log.info("Location 1 got infected during three hours - creating pre-traces");
-    const preTrace1_1 = Section7.genPreTrace(location1.mtr, counter1 - 1);
-    const preTrace1_2 = Section7.genPreTrace(location1.mtr, counter1);
-    const preTrace1_3 = Section7.genPreTrace(location1.mtr, counter1 + 1);
+    const [preTrace1_1, tr_proof1] = CrowdNotifierPrimitives.genPreTrace(location1.mtr, counter1-1);
+    const [preTrace1_2, tr_proof2] = CrowdNotifierPrimitives.genPreTrace(location1.mtr, counter1);
+    const [preTrace1_3, tr_proof3] = CrowdNotifierPrimitives.genPreTrace(location1.mtr, counter1+1);
     log.info("Creating traces from health authority")
-    const trace1_1 = Section7.genTrace(HealthAuthority, counter1 - 1, preTrace1_1);
-    const trace1_2 = Section7.genTrace(HealthAuthority, counter1, preTrace1_2);
-    const trace1_3 = Section7.genTrace(HealthAuthority, counter1 + 1, preTrace1_3);
-    if (trace1_1 === undefined || trace1_2 === undefined || trace1_3 === undefined) {
+    const trace1_1 = CrowdNotifierPrimitives.genTrace(HealthAuthority, preTrace1_1);
+    const trace1_2 = CrowdNotifierPrimitives.genTrace(HealthAuthority, preTrace1_2);
+    const trace1_3 = CrowdNotifierPrimitives.genTrace(HealthAuthority, preTrace1_3);
+    if (trace1_1 === undefined || trace1_2 === undefined || trace1_3 === undefined){
         throw new Error("Couldn't create the traces");
     }
 
     log.info("Checking if user1 gets correctly notified");
-    log.assert(Section7.match(user1, trace1_1), undefined, "Shouldn't match counter-1");
-    log.assert(Section7.match(user1, trace1_2), user1Aux, "Should match counter");
-    log.assert(Section7.match(user1, trace1_3), undefined, "Shouldn't match counter+1");
+    log.assert(CrowdNotifierPrimitives.match(user1, trace1_1), undefined, "Shouldn't match counter-1");
+    log.assert(CrowdNotifierPrimitives.match(user1, trace1_2), user1Aux, "Should match counter");
+    log.assert(CrowdNotifierPrimitives.match(user1, trace1_3), undefined, "Shouldn't match counter+1");
 
     log.info("Checking if user2 gets correctly NOT notified");
-    log.assert(Section7.match(user2, trace1_1), undefined, "Shouldn't match user2");
-    log.assert(Section7.match(user2, trace1_2), undefined, "Shouldn't match user2");
-    log.assert(Section7.match(user2, trace1_3), undefined, "Shouldn't match user2");
+    log.assert(CrowdNotifierPrimitives.match(user2, trace1_1), undefined, "Shouldn't match user2");
+    log.assert(CrowdNotifierPrimitives.match(user2, trace1_2), undefined, "Shouldn't match user2");
+    log.assert(CrowdNotifierPrimitives.match(user2, trace1_3), undefined, "Shouldn't match user2");
+}
+
+// Benchmarks functions.
+
+function statistics(arr) {
+    // Q&D code found there: https://stackoverflow.com/questions/7343890/standard-deviation-javascript
+    const n = arr.length
+    const total = arr.reduce((a,b) => a + b)
+    const mean = total / n
+    const stddev = Math.sqrt(arr.map(x => Math.pow(x - mean, 2)).reduce((a, b) => a + b) / n)
+
+    log.info(`total time: ${total} ms`)
+    log.info(`mean: ${mean} ms`)
+    log.info(`stddev: ${stddev} ms`)
+}
+
+function benchmark_fancy_hash() {
+    const nr_exp = 1000
+    const info_len = 35
+    const nonce_len = 32
+
+    const infos = new Array(nr_exp)
+    const nonces_1 = new Array(nr_exp)
+    const nonces_2 = new Array(nr_exp)
+
+    const times = new Array(nr_exp)
+
+    let t0;
+    let t1;
+    let dt;
+
+    log.info(`Start fancy hash benchmark with ${nr_exp} experiments.`)
+
+
+    for (let i = 0; i < nr_exp; ++i) {
+        infos[i] = randombytes_buf(info_len)
+        nonces_1[i] = randombytes_buf(nonce_len)
+        nonces_2[i] = randombytes_buf(nonce_len)
+    }
+
+    log.info("Fancy hash function.")
+
+    for (let i = 0; i < nr_exp; ++i) {
+        let info = infos[i]
+        let nonce1 = nonces_1[i]
+        let nonce2 = nonces_2[i]
+
+        t0 = performance.now()
+
+        let buf = new Uint8Array(info.length + nonce1.length)
+        buf.set(nonce1)
+        buf.set(info, nonce1.length)
+
+        let h1 = crypto_hash_sha256(buf)
+
+        let buf2 = new Uint8Array(h1.length + nonce2.length)
+        buf2.set(h1)
+        buf2.set(nonce2, h1.length)
+
+        crypto_hash_sha256(buf2)
+
+        t1 = performance.now()
+        dt = t1 - t0
+        times[i] = dt
+    }
+
+    statistics(times)
+}
+
+function benchmark_encryption_round() {
+    const id_len = 32
+    const msg_len = 32
+    const nr_exp = 1000
+
+    const ids = new Array(nr_exp)
+    const msgs = new Array(nr_exp)
+    const skids = new Array(nr_exp)
+
+    const times = new Array(nr_exp)
+
+    let t0;
+    let t1;
+    let dt;
+
+    log.info(`Start benchmark for encryption round with ${nr_exp} experiments.`)
+
+    const [mpk, msk] = IBEPrimitives.keyGen();
+
+    for (let i = 0; i < nr_exp; ++i) {
+        ids[i] = randombytes_buf(id_len)
+        msgs[i] = randombytes_buf(msg_len)
+        skids[i] = IBEPrimitives.keyDer(msk, ids[i]);
+    }
+
+    
+    for (let i = 0; i < nr_exp; ++i) {
+        let ctxt;
+        const id = ids[i]
+        t0 = performance.now()
+        ctxt = IBEPrimitives.enc(mpk, id, msgs[i]);
+        IBEPrimitives.dec(id, skids[i], ctxt);
+        t1 = performance.now()
+        dt = t1 - t0
+        times[i] = dt
+    }
+
+    statistics(times)
+
+}
+
+function benchmark_bad_decrypt() {
+    const id_len = 32
+    const msg_len = 32
+    const nr_exp = 1000
+
+    const ids = new Array(nr_exp)
+    const msgs = new Array(nr_exp)
+    const skids = new Array(nr_exp)
+
+    const times = new Array(nr_exp)
+
+    let t0;
+    let t1;
+    let dt;
+
+    log.info(`Start benchmark for bad decryption with ${nr_exp} experiments.`)
+
+    const [mpk, msk] = IBEPrimitives.keyGen();
+    const [mpk2, msk2] = IBEPrimitives.keyGen();
+
+    for (let i = 0; i < nr_exp; ++i) {
+        ids[i] = randombytes_buf(id_len)
+        msgs[i] = randombytes_buf(msg_len)
+        skids[i] = IBEPrimitives.keyDer(msk2, ids[i]);
+    }
+
+    
+    for (let i = 0; i < nr_exp; ++i) {
+        const id = ids[i]
+        const ctxt = IBEPrimitives.enc(mpk, id, msgs[i]);
+        t0 = performance.now()
+        IBEPrimitives.dec(id, skids[i], ctxt);
+        t1 = performance.now()
+        dt = t1 - t0
+        times[i] = dt
+    }
+
+    statistics(times)
+
+}
+
+function benchmark() {
+    const id_len = 32
+    const msg_len = 32
+    const nr_exp = 1000
+
+    const ids = new Array(nr_exp)
+    const msgs = new Array(nr_exp)
+    const ctxts = new Array(nr_exp)
+    const skids = new Array(nr_exp)
+
+    const g1s = new Array(nr_exp)
+    const g2s = new Array(nr_exp)
+
+    const t_pair = new Array(nr_exp)
+    const t_kg = new Array(nr_exp)
+    const t_enc = new Array(nr_exp)
+    const t_kd = new Array(nr_exp)
+    const t_dec = new Array(nr_exp)
+
+    let t0;
+    let t1;
+    let dt;
+
+    log.info(`Start benchmark with ${nr_exp} experiments.`)
+
+    for (let i = 0; i < nr_exp; ++i) {
+        ids[i] = randombytes_buf(id_len)
+        msgs[i] = randombytes_buf(msg_len)
+
+        const f1 = new mcl.Fr();
+        f1.setByCSPRNG();
+        const g1 = mcl.mul(Helpers.baseG1(), f1);
+        g1s[i] = g1
+
+        const f2 = new mcl.Fr();
+        f2.setByCSPRNG();
+        const g2 = mcl.mul(Helpers.baseG2(), f1);
+        g2s[i] = g2
+    }
+
+    log.info("Pairing primitive.")
+
+    for (let i = 0; i < nr_exp; ++i) {
+        let g1 = g1s[i]
+        let g2 = g2s[i]
+        t0 = performance.now()
+        mcl.pairing(g1, g2)
+        t1 = performance.now()
+        dt = t1 - t0
+        t_pair[i] = dt
+    }
+
+    statistics(t_pair)
+
+
+    log.info("Keys generation.")
+
+    for (let i = 0; i < nr_exp; ++i) {
+        t0 = performance.now()
+        IBEPrimitives.keyGen()
+        t1 = performance.now()
+        dt = t1 - t0
+        t_kg[i] = dt
+    }
+
+    statistics(t_kg)
+
+    const [mpk, msk] = IBEPrimitives.keyGen();
+
+
+    log.info("Encryption")
+    
+    for (let i = 0; i < nr_exp; ++i) {
+        let ctxt;
+        t0 = performance.now()
+        ctxt = IBEPrimitives.enc(mpk, ids[i], msgs[i]);
+        t1 = performance.now()
+        dt = t1 - t0
+        ctxts[i] = ctxt
+        t_enc[i] = dt
+    }
+
+    statistics(t_enc)
+
+
+    log.info("Key derivation")
+    
+    for (let i = 0; i < nr_exp; ++i) {
+        let skid;
+        t0 = performance.now()
+        skid = IBEPrimitives.keyDer(msk, ids[i]);
+        t1 = performance.now()
+        dt = t1 - t0
+        skids[i] = skid
+        t_kd[i] = dt
+    }
+
+    statistics(t_kd)
+
+
+    log.info("Decryption")
+    
+    for (let i = 0; i < nr_exp; ++i) {
+        t0 = performance.now()
+        IBEPrimitives.dec(ids[i], skids[i], ctxts[i]);
+        t1 = performance.now()
+        dt = t1 - t0
+        t_dec[i] = dt
+    }
+
+    statistics(t_dec)
+
+}
+
+
+async function main(){
+    await waitReady();
+
+    log.info("Start test suite for crypto.")
+
+    testIbePrimitives();
+    testCrowdNotifierPrimitives()
 
     log.info("Crypto spec successfully finished!");
+    
+    log.info("Start benchmarks.")
+
+    //benchmark()
+    //benchmark_fancy_hash()
+    //benchmark_encryption_round()
+    //benchmark_bad_decrypt()
+
+    log.info("Benchmarks finished.")
+
 }
 
 main().catch(e => {

--- a/v2/messages.proto
+++ b/v2/messages.proto
@@ -12,28 +12,69 @@ message QRCodeEntry {
   LocationData data = 2;
 }
 
+message MasterTrace {
+  bytes mpk = 1;
+  bytes mskv = 2;
+  bytes mskhEnc = 3;
+  string info = 4;
+  bytes nonce1 = 5;
+  bytes nonce2 = 6;
+}
+
+message EntProof {
+  bytes nonce1 = 1;
+  bytes nonce2 = 2;
+}
+
 message LocationData {
   bytes ent = 1;
-  bytes pEnt = 2;
+  EntProof pEnt = 2;
   MasterTrace mtr = 3;
 }
 
-message MasterTrace {
-  bytes mskv = 1;
-  string info = 2;
-  bytes nonce = 3;
-  bytes mskHAEnc = 4;
+message PreTrace {
+  bytes id = 1;
+  bytes mskhEnc = 2;
+  bytes preskid = 3;
 }
 
-message Commitment {
+message TraceProof {
+    bytes mpk = 1;
+    bytes nonce1 = 2;
+    bytes nonce2 = 3;
+}
+
+message PreTraceWithProof {
+  PreTrace pretrace = 1;
+  TraceProof proof = 2;
+  string  info = 3;
+}
+
+message Trace {
+  bytes id = 1;
+  bytes skid = 2;
+}
+
+message IBEIdInternal1 {
   string info = 1;
   bytes nonce = 2;
-  uint32 counter = 3;
 }
 
-message PreTrace {
-    bytes Tprime = 1;
-    string info = 2;
-    bytes nonce = 3;
-    bytes ctxt = 4;
+message IBEIdInternal2 {
+  bytes hash = 1;
+  uint32 cnt = 2;
+  bytes nonce = 3;
+}
+
+message IBEEncInternal {
+  bytes x = 1;
+  bytes m = 2;
+  bytes id = 3;
+}
+
+message IBEEncryptedData {
+  bytes c1 = 1;
+  bytes c2 = 2;
+  bytes c3 = 3;
+  bytes nonce = 4;
 }

--- a/v2/messages.proto
+++ b/v2/messages.proto
@@ -71,10 +71,3 @@ message IBEEncInternal {
   bytes m = 2;
   bytes id = 3;
 }
-
-message IBEEncryptedData {
-  bytes c1 = 1;
-  bytes c2 = 2;
-  bytes c3 = 3;
-  bytes nonce = 4;
-}

--- a/v2/proto.ts
+++ b/v2/proto.ts
@@ -10,36 +10,84 @@ export class QRCodeEntry extends Message<QRCodeEntry> {
     data: LocationData;
 }
 
-export class LocationData extends Message<LocationData> {
+export class MasterTrace extends Message<MasterTrace> {
+    mpk: Uint8Array;
+    mskv: Uint8Array;
+    mskhEnc: Uint8Array;
+    info: string;
+    nonce1: Uint8Array;
+    nonce2: Uint8Array;
+}
+
+export class EntProof extends Message<EntProof> {
+    nonce1: Uint8Array;
+    nonce2: Uint8Array;
+}
+
+export class LocationData extends Message<Location> {
     ent: Uint8Array;
-    pEnt: Uint8Array;
+    pEnt: EntProof;
     mtr: MasterTrace;
 }
 
-export class MasterTrace extends Message<MasterTrace> {
-    mskv: Uint8Array;
-    info: string;
-    nonce: Uint8Array;
-    mskHAEnc: Uint8Array;
-}
-
-export class Commitment extends Message<Commitment> {
-    info: string;
-    nonce: Uint8Array;
-    counter: number;
-}
-
 export class PreTrace extends Message<PreTrace> {
-    Tprime: Uint8Array;
+    id: Uint8Array;
+    mskhEnc: Uint8Array;
+    preskid: Uint8Array;
+}
+
+export class TraceProof extends Message<TraceProof> {
+    mpk: Uint8Array;
+    nonce1: Uint8Array;
+    nonce2: Uint8Array;
+}
+
+export class PreTraceWithProof extends Message<PreTraceWithProof> {
+    pretrace: PreTrace;
+    proof: TraceProof;
+    info: string;
+}
+
+export class Trace extends Message<Trace> {
+    id: Uint8Array;
+    skid: Uint8Array;
+}
+
+export class IBEIdInternal1 extends Message<IBEIdInternal1> {
     info: string;
     nonce: Uint8Array;
-    ctxt: Uint8Array;
+}
+
+export class IBEIdInternal2 extends Message<IBEIdInternal2> {
+    hash: Uint8Array;
+    cnt: number;
+    nonce: Uint8Array;
+}
+
+export class IBEEncInternal extends Message<IBEEncInternal> {
+    x: Uint8Array;
+    m: Uint8Array;
+    id: Uint8Array;
+}
+
+export class IBEEncryptedData extends Message<IBEEncryptedData> {
+    c1: Uint8Array;
+    c2: Uint8Array;
+    c3: Uint8Array;
+    nonce: Uint8Array;
 }
 
 const protoRoot = loadSync("v2/messages.proto");
 protoRoot.lookupType("crowdnotifier_v2.QRCodeTrace").ctor = QRCodeTrace;
 protoRoot.lookupType("crowdnotifier_v2.QRCodeEntry").ctor = QRCodeEntry;
-protoRoot.lookupType("crowdnotifier_v2.LocationData").ctor = LocationData;
 protoRoot.lookupType("crowdnotifier_v2.MasterTrace").ctor = MasterTrace;
-protoRoot.lookupType("crowdnotifier_v2.Commitment").ctor = Commitment;
+protoRoot.lookupType("crowdnotifier_v2.EntProof").ctor = EntProof;
+protoRoot.lookupType("crowdnotifier_v2.LocationData").ctor = LocationData;
 protoRoot.lookupType("crowdnotifier_v2.PreTrace").ctor = PreTrace;
+protoRoot.lookupType("crowdnotifier_v2.TraceProof").ctor = TraceProof;
+protoRoot.lookupType("crowdnotifier_v2.PreTraceWithProof").ctor = PreTraceWithProof;
+protoRoot.lookupType("crowdnotifier_v2.Trace").ctor = Trace;
+protoRoot.lookupType("crowdnotifier_v2.IBEIdInternal1").ctor = IBEIdInternal1;
+protoRoot.lookupType("crowdnotifier_v2.IBEIdInternal2").ctor = IBEIdInternal2;
+protoRoot.lookupType("crowdnotifier_v2.IBEEncInternal").ctor = IBEEncInternal;
+protoRoot.lookupType("crowdnotifier_v2.IBEEncryptedData").ctor = IBEEncryptedData;

--- a/v2/proto.ts
+++ b/v2/proto.ts
@@ -70,13 +70,6 @@ export class IBEEncInternal extends Message<IBEEncInternal> {
     id: Uint8Array;
 }
 
-export class IBEEncryptedData extends Message<IBEEncryptedData> {
-    c1: Uint8Array;
-    c2: Uint8Array;
-    c3: Uint8Array;
-    nonce: Uint8Array;
-}
-
 const protoRoot = loadSync("v2/messages.proto");
 protoRoot.lookupType("crowdnotifier_v2.QRCodeTrace").ctor = QRCodeTrace;
 protoRoot.lookupType("crowdnotifier_v2.QRCodeEntry").ctor = QRCodeEntry;
@@ -90,4 +83,3 @@ protoRoot.lookupType("crowdnotifier_v2.Trace").ctor = Trace;
 protoRoot.lookupType("crowdnotifier_v2.IBEIdInternal1").ctor = IBEIdInternal1;
 protoRoot.lookupType("crowdnotifier_v2.IBEIdInternal2").ctor = IBEIdInternal2;
 protoRoot.lookupType("crowdnotifier_v2.IBEEncInternal").ctor = IBEEncInternal;
-protoRoot.lookupType("crowdnotifier_v2.IBEEncryptedData").ctor = IBEEncryptedData;

--- a/v2/system.spec.ts
+++ b/v2/system.spec.ts
@@ -39,14 +39,14 @@ async function main() {
     }
 
     log.info("Checking if visit1 gets correctly notified");
-    log.assert(visit1.verifyExposure([trace1_1]), false, "Shouldn't match counter-1");
-    log.assert(visit1.verifyExposure([trace1_2]), true, "Should match counter");
-    log.assert(visit1.verifyExposure([trace1_3]), false,"Shouldn't match counter+1");
+    log.assertTrue(!visit1.verifyExposure([trace1_1]), "Shouldn't match counter-1");
+    log.assertTrue(visit1.verifyExposure([trace1_2]), "Should match counter");
+    log.assertTrue(!visit1.verifyExposure([trace1_3]), "Shouldn't match counter+1");
 
     log.info("Checking if visit2 gets correctly NOT notified");
-    log.assert(visit2.verifyExposure([trace1_1]), false, "Shouldn't match visit2");
-    log.assert(visit2.verifyExposure([trace1_2]), false, "Shouldn't match visit2");
-    log.assert(visit2.verifyExposure([trace1_3]), false, "Shouldn't match visit2");
+    log.assertTrue(!visit2.verifyExposure([trace1_1]), "Shouldn't match visit2");
+    log.assertTrue(!visit2.verifyExposure([trace1_2]), "Shouldn't match visit2");
+    log.assertTrue(!visit2.verifyExposure([trace1_3]), "Shouldn't match visit2");
 
     log.info("System check successfully finished!");
 }

--- a/v2/system.ts
+++ b/v2/system.ts
@@ -1,7 +1,7 @@
-import {ILocationData, IPreTrace, CrowdNotifierPrimitives} from "./crypto";
+import {ILocationData, IEncryptedData, CrowdNotifierPrimitives} from "./crypto";
 import {from_base64, to_base64} from "../lib/sodium";
 import * as mcl from "../lib/mcl";
-import {MasterTrace, PreTrace, LocationData, QRCodeEntry, QRCodeTrace, Trace, PreTraceWithProof} from "./proto";
+import {MasterTrace, LocationData, QRCodeEntry, QRCodeTrace, Trace, PreTraceWithProof} from "./proto";
 
 /**
  * The System package uses the crypto but only passes around base64 encoded protobuf messages. This helps to
@@ -167,7 +167,7 @@ export class Location {
  */
 export class Visit {
     public identity: string;
-    private data: Uint8Array;
+    private data: IEncryptedData;
 
     constructor(
         qrCodeEntry: string,


### PR DESCRIPTION
### Proposed changes

- I corrected the mcl wrapper to wrap GT into an additive group. An other solution would be to keep GT multiplicative, but that would require more change in the mcl wrapper.
- I added some logging function to check the functions returning a boolean value.
- As it was possible to do it in this system, I separated the low-level crypto API from the rest of the code. More specifically, I splitted the class `Section7` into `IBEPrimitives` (contains the low-level crypto API described in the section 5 of the paper) and `CrowdNotifierPrimitives` (contains the low-level system API described in section4 of the paper).