### PR TITLE
Update READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The following repositories hold further information about the project:
 
 * Android SDK: [crowdnotifier-sdk-android](https://github.com/CrowdNotifier/crowdnotifier-sdk-android)
 * iOS SDK: [crowdnotifier-sdk-ios](https://github.com/CrowdNotifier/crowdnotifier-sdk-ios)
-* TypeScript Reference Implementation: [crowdnotifier-ts](https://github.com/CrowdNotifier/crowdnotifier-ts)
+* TypeScript Reference Implementation and library: [libcrowdnotifier](https://github.com/CrowdNotifier/libcrowdnotifier)
 * Android Demo App: [notifyme-app-android](https://github.com/notifyme-app/notifyme-app-android)
 * iOS Demo App: [notifyme-app-ios](https://github.com/notifyme-app/notifyme-app-ios)
 * Backend SDK: [notifyme-sdk-backend](https://github.com/notifyme-app/notifyme-sdk-backend)
@@ -38,9 +38,9 @@ The following repositories hold further information about the project:
 
 ## Work in Progress
 
-The CrowdNotifier protocol is undergoing changes to improve its security and privacy properties. See 
-[CrowdNotifier](https://github.com/CrowdNotifier/documents) for updates on the design. This reference implementation
-will be updated to reflect these changes.
+The CrowdNotifier protocol underwent changes to improve its security and privacy properties. See 
+[CrowdNotifier](https://github.com/CrowdNotifier/documents) for updates on the design. 
+This reference implementation reflects the latest changes as of 2020/12/17
 
 # CrowdNotifier Reference Implementation
 
@@ -64,35 +64,46 @@ This figure shows the steps to publish a trace location:
 - Being able to print intermediate results for test data
 - Insert test data from the main
 - Test with different versions of the QRCode
+- Offer a library for other apps
 
 ## Directories
 
-- lib - types of mcl and sodium libraries
-- [v1](v1/README.md) - first crypto implementation early November 2020
-- [v1_1](V1_1/README.md) - improved crypto implementation without switching ed25519/curve25519,
-according to the white paper from the 26th of November 2020
-- [v2](v2/README.md) - latest changes in crowdNotifier - section7
-- app - DEFUNCT - the previous app all in one
+- [lib](lib/README.md) - the library of the v2 version, including the old v1 and v1_1 for reference
+- [app](app/README.md) - example of how to use the library in an app
 
 ## Starting the tests
 
-To start the tests, run the following commands:
+To start the tests of the library, run the following commands:
 
 ```
-npm ci
-npm start
+cd lib
+npm ci -D
+npm run test
 ```
 
-[Section7 README](v2/README.md)
+For the tests of the app, go into the app-directory, and do the same:
 
-## Next Steps
+```
+cd app
+npm ci -D
+npm run test
+```
 
-This reference implementation is just to show how the pieces fit together from a programmers' perspective.
-The following steps are in the pipeline:
+# Library usage
 
-- separate the crypto in its own package - done
-- implement latest changes in CrowdNotifier white paper - done
-- use it as a web-app
+To use the library, first you need to install it:
+
+```
+npm i -S @c4dt/libcrowdnotifier
+```
+
+If you're using libsodium or mcl in your own app, be sure to import them from the libcrowdnotifier
+package! This is a limitation due to the fact that both libsodium and mcl need to initialize first.
+If you're using your own libsodium and mcl imports, node will treat them as a separate package!
+
+# Versions
+
+- 1.0.0 - 20/12/17 - first version 
 
 # Contributing
 

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -43,6 +43,14 @@
         }
       }
     },
+    "@c4dt/libcrowdnotifier": {
+      "version": "file:../lib",
+      "requires": {
+        "libsodium-wrappers-sumo": "^0.7.8",
+        "mcl-wasm": "^0.7.1",
+        "protobufjs": "^6.10.1"
+      }
+    },
     "@eslint/eslintrc": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.2.2.tgz",
@@ -916,14 +924,6 @@
       "requires": {
         "prelude-ls": "^1.2.1",
         "type-check": "~0.4.0"
-      }
-    },
-    "libcrowdnotifier": {
-      "version": "file:../lib",
-      "requires": {
-        "libsodium-wrappers-sumo": "^0.7.8",
-        "mcl-wasm": "^0.7.1",
-        "protobufjs": "^6.10.1"
       }
     },
     "libsodium-sumo": {

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "libcrowdnotifier-system",
-  "repository": "https://github.com/CrowdNotifier/crowdnotifier-ts",
+  "repository": "https://github.com/CrowdNotifier/libcrowdnotifier",
   "license": "MPL-2.0",
   "author": "Linus Gasser <linus.gasser@epfl.ch>",
   "version": "1.0.0",
@@ -14,7 +14,7 @@
     "testv2": "npx ts-node v2/system.spec.ts"
   },
   "dependencies": {
-    "libcrowdnotifier": "file:../lib",
+    "@c4dt/libcrowdnotifier": "file:../lib",
     "libsodium-wrappers-sumo": "^0.7.8",
     "mcl-wasm": "^0.7.1",
     "protobufjs": "^6.10.2"

--- a/app/v1/system.spec.ts
+++ b/app/v1/system.spec.ts
@@ -1,4 +1,4 @@
-import {Log, sodium} from 'libcrowdnotifier';
+import {Log, sodium} from '@c4dt/libcrowdnotifier';
 import {HealthAuthority, Location, Visit} from './system';
 
 const log = new Log('v1/system.spec');

--- a/app/v1/system.ts
+++ b/app/v1/system.ts
@@ -1,5 +1,4 @@
-import {IKeyPair, sodium} from 'libcrowdnotifier';
-import {v1} from 'libcrowdnotifier';
+import {IKeyPair, sodium, v1} from '@c4dt/libcrowdnotifier';
 
 /**
  * The System package uses the crypto but only passes around base64

--- a/app/v1_1/system.spec.ts
+++ b/app/v1_1/system.spec.ts
@@ -1,4 +1,4 @@
-import {Log, sodium} from 'libcrowdnotifier';
+import {Log, sodium} from '@c4dt/libcrowdnotifier';
 import {HealthAuthority, Location, Visit} from './system';
 
 const log = new Log('v1_1/system.spec');

--- a/app/v1_1/system.ts
+++ b/app/v1_1/system.ts
@@ -1,4 +1,4 @@
-import {IKeyPair, sodium, v1_1} from 'libcrowdnotifier';
+import {IKeyPair, sodium, v1_1} from '@c4dt/libcrowdnotifier';
 
 export interface ITrace {
     tr: v1_1.tr;

--- a/app/v2/system.spec.ts
+++ b/app/v2/system.spec.ts
@@ -1,4 +1,4 @@
-import {Log, waitReady} from 'libcrowdnotifier';
+import {Log, waitReady} from '@c4dt/libcrowdnotifier';
 import {HealthAuthority, Location, Visit} from './system';
 
 const log = new Log('v2/system.spec');

--- a/app/v2/system.ts
+++ b/app/v2/system.ts
@@ -1,5 +1,5 @@
 import {
-  genCode, genPreTrace, genTrace, ILocationData,
+  genCode, genPreTrace, genTrace, IEncryptedData, ILocationData,
   LocationData,
   MasterTrace, match,
   mcl,
@@ -8,8 +8,7 @@ import {
   setupHA,
   sodium,
   Trace, verifyTrace,
-} from 'libcrowdnotifier';
-import {IEncryptedData} from 'libcrowdnotifier/dist/v2/ibe_primitives';
+} from '@c4dt/libcrowdnotifier';
 
 /**
  * The System package uses the crypto but only passes around
@@ -193,7 +192,7 @@ export class Location {
  * The user has zero or more instances of Visit in his phone.
  */
 export class Visit {
-    public identity: string;
+    public identity = 'undefined';
     private readonly data: IEncryptedData;
 
     constructor(

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "libcrowdnotifier",
-  "repository": "https://github.com/CrowdNotifier/crowdnotifier-ts",
+  "name": "@c4dt/libcrowdnotifier",
+  "repository": "https://github.com/CrowdNotifier/libcrowdnotifier",
   "license": "MPL-2.0",
   "author": "Linus Gasser <linus.gasser@epfl.ch>",
   "version": "1.0.0",

--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -4,6 +4,7 @@ import {
   genCode,
   genPreTrace,
   genTrace,
+  IEncryptedData,
   ILocationData,
   LocationData,
   MasterTrace,
@@ -30,7 +31,7 @@ export interface IKeyPair {
 export {
   // CrowdNotifierPrimitives
   setupHA, genCode, scan, genPreTrace, genTrace, verifyTrace, match,
-  waitReady,
+  waitReady, IEncryptedData,
   // Proto structures needed
   PreTraceWithProof, Trace, QRCodeTrace, QRCodeEntry, LocationData, MasterTrace,
   // Structures

--- a/lib/src/v2/index.ts
+++ b/lib/src/v2/index.ts
@@ -1,6 +1,6 @@
 import {setupHA, genCode, scan, genPreTrace,
   genTrace, verifyTrace, match} from './crowd_notifier_primitives';
-import {waitReady} from './ibe_primitives';
+import {waitReady, IEncryptedData} from './ibe_primitives';
 import {ILocationData} from './structs';
 import {PreTraceWithProof, Trace, QRCodeTrace,
   QRCodeEntry, LocationData, MasterTrace} from './proto';
@@ -8,7 +8,7 @@ import {PreTraceWithProof, Trace, QRCodeTrace,
 export {
   // CrowdNotifierPrimitives
   setupHA, genCode, scan, genPreTrace, genTrace, verifyTrace, match,
-  waitReady,
+  waitReady, IEncryptedData,
   // Proto structures needed
   PreTraceWithProof, Trace, QRCodeTrace, QRCodeEntry, LocationData, MasterTrace,
   // Structures


### PR DESCRIPTION
This PR updates the READMEs to correctly reflect that libcrowdnotifier is a library
now.
It is published at @c4dt/libcrowdnotifier, so all references have been updated, too.