### PR TITLE
using setHashOf instead of setLittleEndianMod

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -3,7 +3,7 @@
   "repository": "https://github.com/CrowdNotifier/libcrowdnotifier",
   "license": "MPL-2.0",
   "author": "Linus Gasser <linus.gasser@epfl.ch>",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "private": false,
   "scripts": {
     "build": "npx tsc --build tsconfig.json",

--- a/app/v2/system.ts
+++ b/app/v2/system.ts
@@ -97,7 +97,7 @@ export class Location {
         location: string,
         room: string,
     ): Uint8Array {
-      return sodium.from_string([venueType, name, location, room].join(':'));
+      return sodium.from_string([venueType, name, location, room].join('::'));
     }
 
     static binary_to_info(bin: Uint8Array): string[] {

--- a/lib/package.json
+++ b/lib/package.json
@@ -3,7 +3,7 @@
   "repository": "https://github.com/CrowdNotifier/libcrowdnotifier",
   "license": "MPL-2.0",
   "author": "Linus Gasser <linus.gasser@epfl.ch>",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "private": false,
   "scripts": {
     "build": "npx tsc --build tsconfig.json",

--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -9,6 +9,7 @@ import {
   QRCodeContent,
   MasterTrace,
   match,
+  baseG1, baseG2, genId,
   PreTrace,
   TraceProof,
   PreTraceWithProof,
@@ -34,6 +35,7 @@ export {
   // CrowdNotifierPrimitives
   setupHA, genCode, scan, genPreTrace, genTrace, verifyTrace, match,
   waitReady, IEncryptedData,
+  baseG1, baseG2, genId,
   // Proto structures needed
   PreTraceWithProof, Trace, PreTrace, TraceProof,
   QRCodeTrace, QRCodeEntry, QRCodeContent, MasterTrace,

--- a/lib/src/v2/helpers.spec.ts
+++ b/lib/src/v2/helpers.spec.ts
@@ -1,0 +1,73 @@
+import {Log} from '../log';
+import {genId} from './helpers';
+import {from_string} from 'libsodium-wrappers-sumo';
+
+const log = new Log('v2/helpers.spec');
+log.info(`Starting at: ${new Date()}`);
+
+interface testVector {
+    nonce1Hex: string,
+    nonce2Hex: string,
+    info: string,
+    counter: number,
+    genIdHex: string
+}
+
+// One set of test vectors for the genId method.
+export function testGenId() {
+  const testVectors: testVector[] = [
+    {
+      nonce1Hex:
+            '983698f1d60535414bdd45ea6d6394d096bfaac29604d330d1c46f60d6525f20',
+      nonce2Hex:
+        '5f227555daf25fdb35034742a79d42d9d65df82d24e290b96f96641cdc8855a6',
+      info: 'EPFL::BS::BS086::0',
+      counter: 447528, // Midnight of 2021-01-20
+      genIdHex:
+        '2ae4194bc6e97d9110123b945328907812bb74bed401149fdf16c264d9a12809',
+    },
+    {
+      nonce1Hex:
+            'a03bf5511f8b30af1471d0ac745a56cea4a2fc58eb350f91da78889c1cd14718',
+      nonce2Hex:
+        'ee3e9ff6633024a309f77c01807db31dc0c7fc0cbe9af9c49e415dd673606492',
+      info: 'EPFL::BS::BS140::0',
+      counter: 447529, // 1AM of 2021-01-20
+      genIdHex:
+        '8de01da9933b14e4541b68d4b0d6fca4fb4c3e50020c6061df4943bf753bc519',
+    },
+    {
+      nonce1Hex:
+            'cc0ef29b2b7b98d79ac770543900fd8232d03779eeff287782f755f9f8896cd1',
+      nonce2Hex:
+        '1641d110723df1e7af410e20fd5af00978b79894acf6c30ab8918860fa3aa919',
+      info: 'EPFL::BS::BS225::0',
+      counter: 447530, // 2AM of 2021-01-20
+      genIdHex:
+        '529fc3193e04e96539a8a384abfa8bf1c728497642149b6a0edbaed9fa46cfa4',
+    },
+    {
+      nonce1Hex:
+            'b4efc7059802f40d02e27c82e163bc0a8cbebef3bcfb1482734d0a7ed4ffda63',
+      nonce2Hex:
+        'de559977c294a23a4c0db992bb4835328f0915c4bd74adc0c646efa75b1469df',
+      info: 'EPFL::BS::BS102::0',
+      counter: 447531, // 2AM of 2021-01-20
+      genIdHex:
+        'ad3acd01f6645b08c37881878fbe4caa644188f3f4d41ce33c4ba535fa1884ec',
+    },
+  ];
+
+  for (const tv of testVectors) {
+    log.info('Verifying genId for', JSON.stringify(tv));
+    log.assertTrue(Buffer.compare(
+        genId(
+            from_string(tv.info),
+            tv.counter,
+            Buffer.from(tv.nonce1Hex, 'hex'),
+            Buffer.from(tv.nonce2Hex, 'hex'),
+        ),
+        Buffer.from(tv.genIdHex, 'hex')) === 0,
+    'Wrong value for id');
+  }
+}

--- a/lib/src/v2/helpers.ts
+++ b/lib/src/v2/helpers.ts
@@ -31,11 +31,6 @@ export function baseG2(): mcl.G2 {
 }
 
 
-export function hashT(gt: mcl.GT): Uint8Array {
-  return crypto_hash_sha256(gt.serialize());
-}
-
-
 export function xor(a: Uint8Array, b: Uint8Array): Uint8Array {
   if (a.length !== b.length) {
     throw new Error('cannot xor two Uint8Arrays of different length');
@@ -64,5 +59,5 @@ export function genId(info: Uint8Array,
       Uint8Array.from([...info, ...nonce1]) );
 
   return crypto_hash_sha256(Uint8Array.from(
-      [...hash1, ...from_string(counter.toString()), ...nonce2]));
+      [...hash1, ...nonce2, ...from_string(counter.toString())]));
 }

--- a/lib/src/v2/helpers.ts
+++ b/lib/src/v2/helpers.ts
@@ -1,6 +1,5 @@
-import {IBEIdentityInternal} from './proto';
 import mcl from 'mcl-wasm';
-import {crypto_hash_sha256} from 'libsodium-wrappers-sumo';
+import {crypto_hash_sha256, from_string} from 'libsodium-wrappers-sumo';
 
 /**
  * New methods and definitions
@@ -64,9 +63,6 @@ export function genId(info: Uint8Array,
   const hash1 = crypto_hash_sha256(
       Uint8Array.from([...info, ...nonce1]) );
 
-  return crypto_hash_sha256(
-      IBEIdentityInternal.encode(
-          IBEIdentityInternal.create({hash: hash1, counter, nonce: nonce2}),
-      ).finish(),
-  );
+  return crypto_hash_sha256(Uint8Array.from(
+      [...hash1, ...from_string(counter.toString()), ...nonce2]));
 }

--- a/lib/src/v2/ibe_primitives.spec.ts
+++ b/lib/src/v2/ibe_primitives.spec.ts
@@ -1,5 +1,6 @@
 import {Log, waitReady} from '..';
 import {dec, enc, keyDer, keyGen} from './ibe_primitives';
+import {testGenId} from './helpers.spec';
 
 /**
  * Very simple crypto test for CrowdNotifierPrimitives using the new
@@ -47,6 +48,7 @@ async function main() {
   log.info('Start test suite for crypto.');
 
   testIbePrimitives();
+  testGenId();
 
   log.info('Crypto spec successfully finished!');
 }

--- a/lib/src/v2/ibe_primitives.ts
+++ b/lib/src/v2/ibe_primitives.ts
@@ -72,7 +72,7 @@ export function enc(mpk: mcl.G2, id: Uint8Array, m: Uint8Array):
   const x = randombytes_buf(NONCE_LENGTH);
 
   const r = new mcl.Fr();
-  r.setHashOf(Uint8Array.from([...x, ...m, ...id]));
+  r.setHashOf(Uint8Array.from([...x, ...id, ...m]));
 
   const c1: mcl.G2 = mcl.mul(baseG2(), r);
 
@@ -111,7 +111,7 @@ export function dec(id: Uint8Array, skid: mcl.G1, ctxt: IEncryptedData):
   // Additional verification.
 
   const r_p = new mcl.Fr();
-  r_p.setHashOf(Uint8Array.from([...x_p, ...msg_p, ...id]));
+  r_p.setHashOf(Uint8Array.from([...x_p, ...id, ...msg_p]));
 
   const c1_p = mcl.mul(baseG2(), r_p);
 

--- a/lib/src/v2/index.ts
+++ b/lib/src/v2/index.ts
@@ -4,11 +4,12 @@ import {waitReady, IEncryptedData} from './ibe_primitives';
 import {ILocationData} from './structs';
 import {PreTraceWithProof, PreTrace, TraceProof, Trace, QRCodeTrace,
   QRCodeEntry, QRCodeContent, MasterTrace} from './proto';
+import {baseG1, baseG2, genId} from './helpers';
 
 export {
   // CrowdNotifierPrimitives
   setupHA, genCode, scan, genPreTrace, genTrace, verifyTrace, match,
-  waitReady, IEncryptedData,
+  waitReady, IEncryptedData, baseG1, baseG2, genId,
   // Proto structures needed
   PreTraceWithProof, Trace, PreTrace, TraceProof,
   QRCodeTrace, QRCodeEntry, QRCodeContent, MasterTrace,

--- a/lib/src/v2/messages.json
+++ b/lib/src/v2/messages.json
@@ -170,38 +170,6 @@
               "id": 2
             }
           }
-        },
-        "IBEIdentityInternal": {
-          "fields": {
-            "hash": {
-              "type": "bytes",
-              "id": 1
-            },
-            "counter": {
-              "type": "uint32",
-              "id": 2
-            },
-            "nonce": {
-              "type": "bytes",
-              "id": 3
-            }
-          }
-        },
-        "IBEEncryptionInternal": {
-          "fields": {
-            "x": {
-              "type": "bytes",
-              "id": 1
-            },
-            "m": {
-              "type": "bytes",
-              "id": 2
-            },
-            "identity": {
-              "type": "bytes",
-              "id": 3
-            }
-          }
         }
       }
     }

--- a/lib/src/v2/messages.proto
+++ b/lib/src/v2/messages.proto
@@ -70,15 +70,3 @@ message Trace {
   bytes identity = 1;
   bytes secretKeyForIdentity = 2;
 }
-
-message IBEIdentityInternal {
-  bytes hash = 1;
-  uint32 counter = 2;
-  bytes nonce = 3;
-}
-
-message IBEEncryptionInternal {
-  bytes x = 1;
-  bytes m = 2;
-  bytes identity = 3;
-}

--- a/lib/src/v2/proto.ts
+++ b/lib/src/v2/proto.ts
@@ -139,24 +139,6 @@ export class Trace extends Message<Trace> {
     secretKeyForIdentity: Uint8Array;
 }
 
-export class IBEIdentityInternal extends Message<IBEIdentityInternal> {
-    // @ts-ignore
-    hash: Uint8Array;
-    // @ts-ignore
-    counter: number;
-    // @ts-ignore
-    nonce: Uint8Array;
-}
-
-export class IBEEncryptionInternal extends Message<IBEEncryptionInternal> {
-    // @ts-ignore
-    x: Uint8Array;
-    // @ts-ignore
-    m: Uint8Array;
-    // @ts-ignore
-    identity: Uint8Array;
-}
-
 try {
   const protoRoot = Root.fromJSON(protoJSON);
   protoRoot.lookupType('crowdnotifier_v2.QRCodeTrace').ctor = QRCodeTrace;
@@ -169,10 +151,6 @@ try {
   protoRoot.lookupType('crowdnotifier_v2.PreTraceWithProof').ctor =
       PreTraceWithProof;
   protoRoot.lookupType('crowdnotifier_v2.Trace').ctor = Trace;
-  protoRoot.lookupType('crowdnotifier_v2.IBEIdentityInternal').ctor =
-      IBEIdentityInternal;
-  protoRoot.lookupType('crowdnotifier_v2.IBEEncryptionInternal').ctor =
-      IBEEncryptionInternal;
 } catch (e) {
   throw new Error('couldn\'t load messages.proto: ' + e.toString());
 }


### PR DESCRIPTION
This PR uses `setHashOf` instead of `setLittleEndianMod` and removes the two helper protobufs for the hashing.