### PR TITLE
Adds npm publish action

### DIFF
--- a/.github/workflows/npm_publish
+++ b/.github/workflows/npm_publish
@@ -5,7 +5,7 @@ name: Publish npm Package
 on:
   create:
     tags:
-      - v*
+      - 'v*'
 
 jobs:
   build:

--- a/.github/workflows/npm_publish
+++ b/.github/workflows/npm_publish
@@ -3,8 +3,9 @@
 name: Publish npm Package
 
 on:
-  release:
-    types: [created]
+  create:
+    tags:
+      - v*
 
 jobs:
   build:

--- a/.github/workflows/npm_publish
+++ b/.github/workflows/npm_publish
@@ -53,4 +53,4 @@ jobs:
       - run: cd app && npm ci
       - run: cd app && npm publish
         env:
-          NODE_AUTH_TOKEN: ${{secrets.npm_token}}
+          NODE_AUTH_TOKEN: ${{SECRETS.NPM_TOKEN}}

--- a/.github/workflows/npm_publish
+++ b/.github/workflows/npm_publish
@@ -1,0 +1,32 @@
+# This workflow will run tests using node and then publish a package to npm when a release is created
+
+name: Publish npm Package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 12
+      - run: npm ci
+      - run: npm test
+
+  publish-npm:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 12
+          registry-url: https://registry.npmjs.org/
+      - run: npm ci
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.npm_token}}

--- a/.github/workflows/npm_publish
+++ b/.github/workflows/npm_publish
@@ -3,23 +3,32 @@
 name: Publish npm Package
 
 on:
-  create:
-    tags:
-      - 'v*'
+  release:
+    types: [created]
 
 jobs:
-  build:
+  build-lib:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
           node-version: 12
-      - run: npm ci
-      - run: npm test
+      - run: cd lib && npm ci
+      - run: cd lib && npm test
+  
+  build-app:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 12
+      - run: cd lib && npm ci
+      - run: cd lib && npm test
 
-  publish-npm:
-    needs: build
+  publish-npm-lib:
+    needs: build-lib
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -27,7 +36,21 @@ jobs:
         with:
           node-version: 12
           registry-url: https://registry.npmjs.org/
-      - run: npm ci
-      - run: npm publish
+      - run: cd lib && npm ci
+      - run: cd lib && npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.npm_token}}
+
+  publish-npm-app:
+    needs: build-app
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 12
+          registry-url: https://registry.npmjs.org/
+      - run: cd app && npm ci
+      - run: cd app && npm publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.npm_token}}


### PR DESCRIPTION
Using the Github default publish to npm without the github package repository option

Closes #15 

Note: For obvious reasons, I cannot add the required NODE_AUTH_TOKEN secret (secrets.npm_token).